### PR TITLE
Info.plist does not need to be part of compiled output

### DIFF
--- a/lib/fastlane/plugin/cordova_screenshots/actions/retrofit_cordova_screenshots_ios_action.rb
+++ b/lib/fastlane/plugin/cordova_screenshots/actions/retrofit_cordova_screenshots_ios_action.rb
@@ -161,10 +161,10 @@ module Fastlane
         #
         # Add files (fastlane configured UI Unit Tests) into target (via test group)
         #
-        UI.message("Adding Pre-Configured UI Unit Tests (*.plist and *.swift) to Test Group '#{scheme_name}'...")
+        UI.message("Adding Pre-Configured UI Unit Tests (*.swift) to Test Group '#{scheme_name}'...")
 
         files = []
-        Dir["#{config_folder}*.plist", "#{config_folder}*.swift"].each do |file| # config_folder ends with / already
+        Dir["#{config_folder}*.swift"].each do |file| # config_folder ends with / already
           UI.message("Adding UI Test Source '#{file}'")
           files << test_group.new_reference(File.absolute_path(file), '<absolute>')
         end


### PR DESCRIPTION
This addresses issue #25 and prevents Info.plist from being produced by both the copy and the build steps.